### PR TITLE
Add support for Business Plan

### DIFF
--- a/quilt_server/const.py
+++ b/quilt_server/const.py
@@ -13,3 +13,5 @@ EMAILREGEX = re.compile(r'^([^\s@]+)@([^\s@]+)$')
 class PaymentPlan(Enum):
     FREE = 'free'
     INDIVIDUAL = 'individual_monthly_7'
+    BUSINESS_ADMIN = 'business_monthly_490'
+    BUSINESS_MEMBER = 'business_member'


### PR DESCRIPTION
Technically, two plans:
- Business admin: pays for the plan and emails us to actually add other people
- Business member: gets all the features without paying, and cannot switch to/from the plan on their own