### PR TITLE
Add a `next` parameter to the /login endpoint

### DIFF
--- a/quilt_server/dev_config.py
+++ b/quilt_server/dev_config.py
@@ -36,6 +36,8 @@ OAUTH.update(dict(
     redirect_url='http://localhost:5000/oauth_callback',
 ))
 
+CATALOG_REDIRECT_URLS = ['http://localhost:3000/oauth_callback']
+
 INVITE_SEND_URL = 'https://quilt-heroku.herokuapp.com/pkginvite/send/'  # XXX
 
 AWS_ACCESS_KEY_ID = 'fake_id'

--- a/quilt_server/prod_config.py
+++ b/quilt_server/prod_config.py
@@ -22,6 +22,8 @@ OAUTH = dict(
     have_refresh_token=True
 )
 
+CATALOG_REDIRECT_URLS = os.environ['CATALOG_REDIRECT_URLS'].split()
+
 PACKAGE_BUCKET_NAME = os.environ['PACKAGE_BUCKET_NAME']
 
 INVITE_SEND_URL = 'https://%s/pkginvite/send/' % OAUTH_API_HOST

--- a/quilt_server/test_config.py
+++ b/quilt_server/test_config.py
@@ -17,6 +17,8 @@ OAUTH = dict(
     have_refresh_token=True,
 )
 
+CATALOG_REDIRECT_URLS = os.getenv('CATALOG_REDIRECT_URLS', '').split()
+
 INVITE_SEND_URL = 'https://quilt-heroku.herokuapp.com/pkginvite/send/'
 
 AWS_ACCESS_KEY_ID = 'fake_id'


### PR DESCRIPTION
This allows the catalog to authenticate using the registry instead of going through its own oauth flow.

(GitHub does not support implicit grants, making it impossible for the catalog to use it directly.)