### PR TITLE
Fix error handling when connection to the auth server fails

### DIFF
--- a/quilt_server/middleware.py
+++ b/quilt_server/middleware.py
@@ -29,6 +29,6 @@ class RequestEncodingMiddleware(object):
         try:
             return self.app(environ, start_response)
         except (OSError, zlib.error) as ex:
-            # gzip raises OSError on invalid import... blah.
+            # gzip raises OSError on invalid input... blah.
             error = "Failed to decode input: %s" % ex
             return BadRequest(error)(environ, start_response)


### PR DESCRIPTION
If connection to the auth server fails (DNS error, etc.), requests raises a ConnectionError. It wasn't caught, causing middleware to report a gzip error.